### PR TITLE
Updating rpc to 0.5.0

### DIFF
--- a/server/1-starter/lib/server/piratesapi.dart
+++ b/server/1-starter/lib/server/piratesapi.dart
@@ -4,7 +4,7 @@
 
 library pirate.server;
 
-import 'package:rpc/api.dart';
+import 'package:rpc/rpc.dart';
 
 import '../common/messages.dart';
 import '../common/utils.dart';

--- a/server/1-starter/pubspec.yaml
+++ b/server/1-starter/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
   crypto: ^0.9.0
   http: ^0.11.1
   logging_handlers: ^0.8.0
-  rpc: ^0.4.1
+  rpc: ^0.5.0

--- a/server/2-simple/lib/server/piratesapi.dart
+++ b/server/2-simple/lib/server/piratesapi.dart
@@ -4,7 +4,7 @@
 
 library pirate.server;
 
-import 'package:rpc/api.dart';
+import 'package:rpc/rpc.dart';
 
 import '../common/messages.dart';
 import '../common/utils.dart';

--- a/server/2-simple/pubspec.yaml
+++ b/server/2-simple/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
   crypto: ^0.9.0
   http: ^0.11.1
   logging_handlers: ^0.8.0
-  rpc: ^0.4.1
+  rpc: ^0.5.0

--- a/server/4-extended/lib/server/piratesapi.dart
+++ b/server/4-extended/lib/server/piratesapi.dart
@@ -4,7 +4,7 @@
 
 library pirate.server;
 
-import 'package:rpc/api.dart';
+import 'package:rpc/rpc.dart';
 
 import '../common/messages.dart';
 import '../common/utils.dart';

--- a/server/4-extended/pubspec.yaml
+++ b/server/4-extended/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
   crypto: ^0.9.0
   http: ^0.11.1
   logging_handlers: ^0.8.0
-  rpc: ^0.4.1
+  rpc: ^0.5.0

--- a/server/5-generated/lib/server/piratesapi.dart
+++ b/server/5-generated/lib/server/piratesapi.dart
@@ -4,7 +4,7 @@
 
 library pirate.server;
 
-import 'package:rpc/api.dart';
+import 'package:rpc/rpc.dart';
 
 import '../common/messages.dart';
 import '../common/utils.dart';

--- a/server/5-generated/pubspec.yaml
+++ b/server/5-generated/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
   crypto: ^0.9.0
   http: ^0.11.1
   logging_handlers: ^0.8.0
-  rpc: ^0.4.1
+  rpc: ^0.5.0

--- a/server/6-client/lib/server/piratesapi.dart
+++ b/server/6-client/lib/server/piratesapi.dart
@@ -4,7 +4,7 @@
 
 library pirate.server;
 
-import 'package:rpc/api.dart';
+import 'package:rpc/rpc.dart';
 
 import '../common/messages.dart';
 import '../common/utils.dart';

--- a/server/6-client/pubspec.yaml
+++ b/server/6-client/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
   crypto: ^0.9.0
   http: ^0.11.1
   logging_handlers: ^0.8.0
-  rpc: ^0.4.1
+  rpc: ^0.5.0

--- a/server/7-serve/lib/server/piratesapi.dart
+++ b/server/7-serve/lib/server/piratesapi.dart
@@ -4,7 +4,7 @@
 
 library pirate.server;
 
-import 'package:rpc/api.dart';
+import 'package:rpc/rpc.dart';
 
 import '../common/messages.dart';
 import '../common/utils.dart';

--- a/server/7-serve/pubspec.yaml
+++ b/server/7-serve/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
   http: ^0.11.1
   http_server: ^0.9.5+1
   logging_handlers: ^0.8.0
-  rpc: ^0.4.1
+  rpc: ^0.5.0

--- a/server/working-dir/lib/server/piratesapi.dart
+++ b/server/working-dir/lib/server/piratesapi.dart
@@ -4,7 +4,7 @@
 
 library pirate.server;
 
-import 'package:rpc/api.dart';
+import 'package:rpc/rpc.dart';
 
 import '../common/messages.dart';
 import '../common/utils.dart';

--- a/server/working-dir/pubspec.yaml
+++ b/server/working-dir/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
   crypto: ^0.9.0
   http: ^0.11.1
   logging_handlers: ^0.8.0
-  rpc: ^0.4.1
+  rpc: ^0.5.0


### PR DESCRIPTION
Server code doesn't work with the new rpc version (0.5.0) since they renamed `lib/api.dart` to `lib/common.dart` in order to isolate server side code on `lib/rpc.dart`, which should be used in this case.

So I updated all the `pubspec.yaml` files and replaced all `api.dart` imports to `rpc.dart`.
