### PR TITLE
Improved example.

### DIFF
--- a/ng2/6-readjsonfile/.analysis_options
+++ b/ng2/6-readjsonfile/.analysis_options
@@ -1,0 +1,16 @@
+# Supported lint rules and documentation: http://dart-lang.github.io/linter/lints/
+linter:
+  rules:
+    - always_declare_return_types
+    - camel_case_types
+    - empty_constructor_bodies
+    - annotate_overrides
+    - avoid_init_to_null
+    - constant_identifier_names
+    - one_member_abstracts
+    - slash_for_doc_comments
+    - sort_constructors_first
+    - unnecessary_brace_in_string_interp
+
+analyzer:
+  strong-mode: true

--- a/ng2/6-readjsonfile/lib/badge_component.dart
+++ b/ng2/6-readjsonfile/lib/badge_component.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:angular2/core.dart';
-import 'pirate_name_service.dart';
+import 'name_service.dart';
 
 @Component(
     selector: 'pirate-badge',

--- a/ng2/6-readjsonfile/lib/name_service.dart
+++ b/ng2/6-readjsonfile/lib/name_service.dart
@@ -9,15 +9,14 @@ import 'dart:math' show Random;
 
 import 'package:angular2/core.dart';
 
-const _namesPath =
-    'https://www.dartlang.org/f/piratenames.json';
+const _namesPath = 'https://www.dartlang.org/f/piratenames.json';
 
 @Injectable()
 class NameService {
   final Random _indexGen = new Random();
 
-  final _names = <String>[];
-  final _appellations = <String>[];
+  final List _names = <String>[];
+  final List _appellations = <String>[];
 
   String _randomFirstName() => _names[_indexGen.nextInt(_names.length)];
 


### PR DESCRIPTION
- Fixed a bug I had missed before. (When renaming the name_service, I had overlooked one of the imports.)
- Made the example strong-mode compliant using an .analysis_options file.

@kwalrath, please review
