### PR TITLE
ng2: drop `platform_directives` and `platform_pipes` from pubspecs

### DIFF
--- a/ng2/1-skeleton/pubspec.yaml
+++ b/ng2/1-skeleton/pubspec.yaml
@@ -10,9 +10,5 @@ dev_dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives:
-    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    platform_pipes:
-    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/ng2/2-blankbadge/pubspec.yaml
+++ b/ng2/2-blankbadge/pubspec.yaml
@@ -10,9 +10,5 @@ dev_dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives:
-    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    platform_pipes:
-    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/ng2/3-inputnamebadge/pubspec.yaml
+++ b/ng2/3-inputnamebadge/pubspec.yaml
@@ -10,9 +10,5 @@ dev_dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives:
-    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    platform_pipes:
-    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/ng2/4-buttonbadge/pubspec.yaml
+++ b/ng2/4-buttonbadge/pubspec.yaml
@@ -10,9 +10,5 @@ dev_dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives:
-    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    platform_pipes:
-    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/ng2/5-piratenameservice/pubspec.yaml
+++ b/ng2/5-piratenameservice/pubspec.yaml
@@ -10,9 +10,5 @@ dev_dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives:
-    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    platform_pipes:
-    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter

--- a/ng2/6-readjsonfile/pubspec.yaml
+++ b/ng2/6-readjsonfile/pubspec.yaml
@@ -10,9 +10,5 @@ dev_dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 transformers:
 - angular2:
-    platform_directives:
-    - 'package:angular2/common.dart#COMMON_DIRECTIVES'
-    platform_pipes:
-    - 'package:angular2/common.dart#COMMON_PIPES'
     entry_points: web/main.dart
 - dart_to_js_script_rewriter


### PR DESCRIPTION
For details see https://github.com/dart-lang/angular2/issues/363

cc @kwalrath 