### PR TITLE
[4-dev] upgraded angular_components codelab

### DIFF
--- a/angular_components/1-base/lib/lottery_simulator.dart
+++ b/angular_components/1-base/lib/lottery_simulator.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'src/help/help.dart';
 import 'src/scores/scores.dart';
 import 'src/settings/settings.dart';

--- a/angular_components/1-base/lib/src/help/help.dart
+++ b/angular_components/1-base/lib/src/help/help.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 @Component(
   selector: 'help-component',

--- a/angular_components/1-base/lib/src/scores/scores.dart
+++ b/angular_components/1-base/lib/src/scores/scores.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 @Component(
   selector: 'scores-component',

--- a/angular_components/1-base/lib/src/settings/settings.dart
+++ b/angular_components/1-base/lib/src/settings/settings.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:components_codelab/src/lottery/lottery.dart';
 
 final DateTime _now = new DateTime.now();

--- a/angular_components/1-base/lib/src/settings/settings.dart
+++ b/angular_components/1-base/lib/src/settings/settings.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:angular/angular.dart';
-import 'package:components_codelab/src/lottery/lottery.dart';
+import '../lottery/lottery.dart';
 
 final DateTime _now = new DateTime.now();
 

--- a/angular_components/1-base/lib/src/settings/settings_component.dart
+++ b/angular_components/1-base/lib/src/settings/settings_component.dart
@@ -3,8 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:angular/angular.dart';
-import 'package:components_codelab/src/lottery/lottery.dart';
-import 'package:components_codelab/src/settings/settings.dart';
+import '../lottery/lottery.dart';
+import '../settings/settings.dart';
 
 import 'dart:async';
 

--- a/angular_components/1-base/lib/src/settings/settings_component.dart
+++ b/angular_components/1-base/lib/src/settings/settings_component.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:components_codelab/src/lottery/lottery.dart';
 import 'package:components_codelab/src/settings/settings.dart';
 

--- a/angular_components/1-base/lib/src/stats/stats.dart
+++ b/angular_components/1-base/lib/src/stats/stats.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 @Component(
   selector: 'stats-component',

--- a/angular_components/1-base/lib/src/visualize_winnings/visualize_winnings.dart
+++ b/angular_components/1-base/lib/src/visualize_winnings/visualize_winnings.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 enum Color { gray, green, gold }
 

--- a/angular_components/1-base/pubspec.yaml
+++ b/angular_components/1-base/pubspec.yaml
@@ -16,8 +16,6 @@ dev_dependencies:
 transformers:
 - angular:
     entry_points: web/main.dart
-    resolved_identifiers:
-      Random: 'dart:math'
 - dart_to_js_script_rewriter
 
 web:

--- a/angular_components/1-base/pubspec.yaml
+++ b/angular_components/1-base/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: '>=1.24.0 <2.0.0'
 
 dependencies:
-  angular2: ^3.0.0
+  angular: ^4.0.0-beta
   intl: ^0.14.0
 
 dev_dependencies:
@@ -14,7 +14,7 @@ dev_dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 
 transformers:
-- angular2:
+- angular:
     entry_points: web/main.dart
     resolved_identifiers:
       Random: 'dart:math'

--- a/angular_components/1-base/web/main.dart
+++ b/angular_components/1-base/web/main.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/platform/browser.dart';
+import 'package:angular/angular.dart';
 import 'package:components_codelab/lottery_simulator.dart';
 
 void main() {

--- a/angular_components/2-starteasy/lib/lottery_simulator.dart
+++ b/angular_components/2-starteasy/lib/lottery_simulator.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 import 'src/help/help.dart';
 import 'src/scores/scores.dart';

--- a/angular_components/2-starteasy/lib/src/help/help.dart
+++ b/angular_components/2-starteasy/lib/src/help/help.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/angular_components/2-starteasy/lib/src/scores/scores.dart
+++ b/angular_components/2-starteasy/lib/src/scores/scores.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/angular_components/2-starteasy/lib/src/settings/settings.dart
+++ b/angular_components/2-starteasy/lib/src/settings/settings.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:components_codelab/src/lottery/lottery.dart';
 
 final DateTime _now = new DateTime.now();

--- a/angular_components/2-starteasy/lib/src/settings/settings.dart
+++ b/angular_components/2-starteasy/lib/src/settings/settings.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:angular/angular.dart';
-import 'package:components_codelab/src/lottery/lottery.dart';
+import '../lottery/lottery.dart';
 
 final DateTime _now = new DateTime.now();
 

--- a/angular_components/2-starteasy/lib/src/settings/settings_component.dart
+++ b/angular_components/2-starteasy/lib/src/settings/settings_component.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 
 import 'package:angular/angular.dart';
-import 'package:components_codelab/src/lottery/lottery.dart';
-import 'package:components_codelab/src/settings/settings.dart';
+import '../lottery/lottery.dart';
+import '../settings/settings.dart';
 
 @Component(
   selector: 'settings-component',

--- a/angular_components/2-starteasy/lib/src/settings/settings_component.dart
+++ b/angular_components/2-starteasy/lib/src/settings/settings_component.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:components_codelab/src/lottery/lottery.dart';
 import 'package:components_codelab/src/settings/settings.dart';
 

--- a/angular_components/2-starteasy/lib/src/stats/stats.dart
+++ b/angular_components/2-starteasy/lib/src/stats/stats.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 @Component(
   selector: 'stats-component',

--- a/angular_components/2-starteasy/lib/src/visualize_winnings/visualize_winnings.dart
+++ b/angular_components/2-starteasy/lib/src/visualize_winnings/visualize_winnings.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 enum Color { gray, green, gold }
 

--- a/angular_components/2-starteasy/pubspec.yaml
+++ b/angular_components/2-starteasy/pubspec.yaml
@@ -17,8 +17,6 @@ dev_dependencies:
 transformers:
 - angular:
     entry_points: web/main.dart
-    resolved_identifiers:
-      Random: 'dart:math'
 - dart_to_js_script_rewriter
 
 web:

--- a/angular_components/2-starteasy/pubspec.yaml
+++ b/angular_components/2-starteasy/pubspec.yaml
@@ -6,8 +6,8 @@ environment:
   sdk: '>=1.24.0 <2.0.0'
 
 dependencies:
-  angular2: ^3.0.0
-  angular_components: ^0.5.0
+  angular: ^4.0.0-beta
+  angular_components: ^0.6.0-beta
   intl: ^0.14.0
 
 dev_dependencies:
@@ -15,7 +15,7 @@ dev_dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 
 transformers:
-- angular2:
+- angular:
     entry_points: web/main.dart
     resolved_identifiers:
       Random: 'dart:math'

--- a/angular_components/2-starteasy/web/main.dart
+++ b/angular_components/2-starteasy/web/main.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/platform/browser.dart';
+import 'package:angular/angular.dart';
 import 'package:components_codelab/lottery_simulator.dart';
 
 void main() {

--- a/angular_components/3-usebuttons/lib/lottery_simulator.dart
+++ b/angular_components/3-usebuttons/lib/lottery_simulator.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 import 'src/help/help.dart';
 import 'src/scores/scores.dart';

--- a/angular_components/3-usebuttons/lib/src/help/help.dart
+++ b/angular_components/3-usebuttons/lib/src/help/help.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/angular_components/3-usebuttons/lib/src/scores/scores.dart
+++ b/angular_components/3-usebuttons/lib/src/scores/scores.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/angular_components/3-usebuttons/lib/src/settings/settings.dart
+++ b/angular_components/3-usebuttons/lib/src/settings/settings.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:components_codelab/src/lottery/lottery.dart';
 
 final DateTime _now = new DateTime.now();

--- a/angular_components/3-usebuttons/lib/src/settings/settings.dart
+++ b/angular_components/3-usebuttons/lib/src/settings/settings.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:angular/angular.dart';
-import 'package:components_codelab/src/lottery/lottery.dart';
+import '../lottery/lottery.dart';
 
 final DateTime _now = new DateTime.now();
 

--- a/angular_components/3-usebuttons/lib/src/settings/settings_component.dart
+++ b/angular_components/3-usebuttons/lib/src/settings/settings_component.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 import 'package:components_codelab/src/lottery/lottery.dart';
 import 'package:components_codelab/src/settings/settings.dart';

--- a/angular_components/3-usebuttons/lib/src/settings/settings_component.dart
+++ b/angular_components/3-usebuttons/lib/src/settings/settings_component.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
-import 'package:components_codelab/src/lottery/lottery.dart';
-import 'package:components_codelab/src/settings/settings.dart';
+import '../lottery/lottery.dart';
+import '../settings/settings.dart';
 
 @Component(
   selector: 'settings-component',

--- a/angular_components/3-usebuttons/lib/src/stats/stats.dart
+++ b/angular_components/3-usebuttons/lib/src/stats/stats.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 @Component(
   selector: 'stats-component',

--- a/angular_components/3-usebuttons/lib/src/visualize_winnings/visualize_winnings.dart
+++ b/angular_components/3-usebuttons/lib/src/visualize_winnings/visualize_winnings.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 enum Color { gray, green, gold }
 

--- a/angular_components/3-usebuttons/pubspec.yaml
+++ b/angular_components/3-usebuttons/pubspec.yaml
@@ -17,8 +17,6 @@ dev_dependencies:
 transformers:
 - angular:
     entry_points: web/main.dart
-    resolved_identifiers:
-      Random: 'dart:math'
 - dart_to_js_script_rewriter
 
 web:

--- a/angular_components/3-usebuttons/pubspec.yaml
+++ b/angular_components/3-usebuttons/pubspec.yaml
@@ -6,8 +6,8 @@ environment:
   sdk: '>=1.24.0 <2.0.0'
 
 dependencies:
-  angular2: ^3.0.0
-  angular_components: ^0.5.0
+  angular: ^4.0.0-beta
+  angular_components: ^0.6.0-beta
   intl: ^0.14.0
 
 dev_dependencies:
@@ -15,7 +15,7 @@ dev_dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 
 transformers:
-- angular2:
+- angular:
     entry_points: web/main.dart
     resolved_identifiers:
       Random: 'dart:math'

--- a/angular_components/3-usebuttons/web/main.dart
+++ b/angular_components/3-usebuttons/web/main.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/platform/browser.dart';
+import 'package:angular/angular.dart';
 import 'package:components_codelab/lottery_simulator.dart';
 
 void main() {

--- a/angular_components/4-final/lib/lottery_simulator.dart
+++ b/angular_components/4-final/lib/lottery_simulator.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 import 'src/help/help.dart';
 import 'src/scores/scores.dart';

--- a/angular_components/4-final/lib/src/help/help.dart
+++ b/angular_components/4-final/lib/src/help/help.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/angular_components/4-final/lib/src/scores/scores.dart
+++ b/angular_components/4-final/lib/src/scores/scores.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 
 @Component(

--- a/angular_components/4-final/lib/src/settings/settings.dart
+++ b/angular_components/4-final/lib/src/settings/settings.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:components_codelab/src/lottery/lottery.dart';
 
 final DateTime _now = new DateTime.now();

--- a/angular_components/4-final/lib/src/settings/settings.dart
+++ b/angular_components/4-final/lib/src/settings/settings.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:angular/angular.dart';
-import 'package:components_codelab/src/lottery/lottery.dart';
+import '../lottery/lottery.dart';
 
 final DateTime _now = new DateTime.now();
 

--- a/angular_components/4-final/lib/src/settings/settings_component.dart
+++ b/angular_components/4-final/lib/src/settings/settings_component.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
 import 'package:components_codelab/src/lottery/lottery.dart';
 import 'package:components_codelab/src/settings/settings.dart';

--- a/angular_components/4-final/lib/src/settings/settings_component.dart
+++ b/angular_components/4-final/lib/src/settings/settings_component.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:angular/angular.dart';
 import 'package:angular_components/angular_components.dart';
-import 'package:components_codelab/src/lottery/lottery.dart';
-import 'package:components_codelab/src/settings/settings.dart';
+import '../lottery/lottery.dart';
+import '../settings/settings.dart';
 
 @Component(
   selector: 'settings-component',

--- a/angular_components/4-final/lib/src/stats/stats.dart
+++ b/angular_components/4-final/lib/src/stats/stats.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 @Component(
   selector: 'stats-component',

--- a/angular_components/4-final/lib/src/visualize_winnings/visualize_winnings.dart
+++ b/angular_components/4-final/lib/src/visualize_winnings/visualize_winnings.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:angular2/angular2.dart';
+import 'package:angular/angular.dart';
 
 enum Color { gray, green, gold }
 

--- a/angular_components/4-final/pubspec.yaml
+++ b/angular_components/4-final/pubspec.yaml
@@ -17,8 +17,6 @@ dev_dependencies:
 transformers:
 - angular:
     entry_points: web/main.dart
-    resolved_identifiers:
-      Random: 'dart:math'
 - dart_to_js_script_rewriter
 
 web:

--- a/angular_components/4-final/pubspec.yaml
+++ b/angular_components/4-final/pubspec.yaml
@@ -6,8 +6,8 @@ environment:
   sdk: '>=1.24.0 <2.0.0'
 
 dependencies:
-  angular2: ^3.0.0
-  angular_components: ^0.5.0
+  angular: ^4.0.0-beta
+  angular_components: ^0.6.0-beta
   intl: ^0.14.0
 
 dev_dependencies:
@@ -15,7 +15,7 @@ dev_dependencies:
   dart_to_js_script_rewriter: ^1.0.1
 
 transformers:
-- angular2:
+- angular:
     entry_points: web/main.dart
     resolved_identifiers:
       Random: 'dart:math'

--- a/angular_components/4-final/web/main.dart
+++ b/angular_components/4-final/web/main.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:angular2/platform/browser.dart';
+import 'package:angular/angular.dart';
 import 'package:components_codelab/lottery_simulator.dart';
 
 void main() {


### PR DESCRIPTION
This is #44, with Angular upgraded to 4.0.0-beta.

The codelab apps are (temporarily) hosted via:
- `master`: http://dart-lang.github.io/one-hour-codelab/3/
- `4-dev`: http://dart-lang.github.io/one-hour-codelab/4/